### PR TITLE
Use namespaced Dockerfile.ddev-cron

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,31 +12,22 @@ This DDEV add-on helps to execute a command in the web container based on a cron
 The add-on 
 * Installs and runs the cron service inside the web container
 * Adds a sample cron configuration that adds to a file every minute.
+* Required DDEV v1.19.3 or higher.
 
-**Warning**
-If you already have a `.ddev/web-build/Dockerfile` in your project, you'll want to adapt it with
-the one provided here, and `ddev get` will override the one you have.
-
-
-This extension is designed to be a generic implentation. See [Running TYPO3 Cron inside the web container](https://github.com/drud/ddev-contrib/tree/master/recipes/cronjob) for a specific example of a manual setup.
+*This extension is designed to be a generic implentation. See [Running TYPO3 Cron inside the web container](https://github.com/drud/ddev-contrib/tree/master/recipes/cronjob) for a specific example of a manual setup.*
 
 ## Getting started
 
-- Install the add-on
-
-```shell
-ddev get tyler36/cron
-```
-
-- Update the provided `./.ddev/config.cron.yaml` as you see fit with your expected cron jobs (and remove the demonstration line). You can also just add the demonstration lines to your `.ddev/config.yaml`.
+- Install the add-on with `ddev get tyler36/ddev-cron`
+- Update the provided `.ddev/config.cron.yaml` as you see fit with your expected cron jobs (and remove the demonstration line). You can also just add those demonstration lines to your `.ddev/config.yaml` and delete the `.ddev/config.cron.yaml`.
 - `ddev restart`
 
 
 ## Implementation
 
-The provided `web-build/Dockerfile` and `web-build/cron.conf` configure the traditional cron daemon to run inside the web container.
+The provided `web-build/Dockerfile.ddev-cron` and `web-build/cron.conf` configure the traditional cron daemon to run inside the web container.
 
-The `config.cron.yaml` is a simple implentation of cron within the DDEV web container. It writes a crontab file to configure the cron daemon.
+The `config.cron.yaml` is a simple setup of a trivial cron job within the DDEV web container. It writes a crontab file to configure the cron daemon.
 
 ```yaml
 hooks:

--- a/config.cron.yaml
+++ b/config.cron.yaml
@@ -1,5 +1,5 @@
 hooks:
-  # This will be executed at the whenever DDEV starts
+  # This will be executed whenever DDEV starts
   post-start:
     # This line creates a job, ddev-cron-time, and configures it to run every minute
     # You can just `ls -l time.log` or `tail time.log` to see it happening.

--- a/install.yaml
+++ b/install.yaml
@@ -1,11 +1,10 @@
 name: ddev-cron
 
-# pre_install_actions - list of actions to run before installing the addon.
-# Examples would be removing an extraneous docker volume,
-# or doing a sanity check for requirements.
 pre_install_actions:
-# - 'if [ "$(arch)" = "arm64" -o "$(arch)" = "aarch64" ]; then echo "This package does not work on arm64 machines"; exit 1; fi'
-# - "docker volume rm ddev-${DDEV_PROJECT}_solr 2>/dev/null || true"
+- |
+  if ! ( ddev debug capabilities 2>/dev/null | grep multiple-dockerfiles >/dev/null 2>&1 ) ; then
+    echo "This add-on requires DDEV v1.19.3 or higher, please upgrade." && exit 2
+  fi
 
 # list of files and directories listed that are copied into project .ddev directory
 project_files:

--- a/web-build/Dockerfile.ddev-cron
+++ b/web-build/Dockerfile.ddev-cron
@@ -1,5 +1,3 @@
-ARG BASE_IMAGE
-FROM $BASE_IMAGE
 # Install cron package; this can be done in webimage_extra_packages, but put it here for now.
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests cron
 # Tell supervisord to start cron service in cron.conf


### PR DESCRIPTION
DDEV v1.19.3 has namespaced Dockerfiles, so we don't need to run the risk of overwriting a Dockerfile that somebody already has. This PR changes to that approach, and guards against it being used in previous DDEV versions. There are also minor docs updates.

This can be tested with `ddev get https://github.com/rfay/ddev-cron/tarball/20220605_use_namespaced_dockerfile` or by checking out the PR and `ddev get /path/to/checkout`