### PR TITLE
Fix tests failing against HEAD, fixes #7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ defaults:
     shell: bash
 
 env:
-  #NIGHTLY_DDEV_PR_URL: "https://nightly.link/drud/ddev/actions/runs/1720215802/ddev-linux-amd64.zip"
+  NIGHTLY_DDEV_PR_URL: "https://nightly.link/drud/ddev/actions/runs/1720215802/ddev-linux-amd64.zip"
 
 jobs:
   tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ defaults:
     shell: bash
 
 env:
-  NIGHTLY_DDEV_PR_URL: "https://nightly.link/drud/ddev/actions/runs/1720215802/ddev-linux-amd64.zip"
+  #NIGHTLY_DDEV_PR_URL: "https://nightly.link/drud/ddev/actions/runs/1720215802/ddev-linux-amd64.zip"
 
 jobs:
   tests:
@@ -29,8 +29,8 @@ jobs:
 
     strategy:
       matrix:
-        ddev_version: [stable, edge, HEAD]
-#        ddev_version: [PR]
+        ddev_version: [stable, HEAD]
+#        ddev_version: [stable, edge, HEAD, PR]
       fail-fast: false
 
     runs-on: ubuntu-20.04

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,1 @@
-#ddev-generated
-# Override the web container's standard HTTP_EXPOSE and HTTPS_EXPOSE
-# This is to expose the browsersync port.
-version: '3.6'
-services:
-  web:
-    expose:
-      - '3000'
-    environment:
-      - HTTP_EXPOSE=${DDEV_ROUTER_HTTP_PORT}:80,${DDEV_MAILHOG_PORT}:8025,3000:3000
-      - HTTPS_EXPOSE=${DDEV_ROUTER_HTTPS_PORT}:80,${DDEV_MAILHOG_HTTPS_PORT}:8025
+/.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,11 @@
-/.idea
+#ddev-generated
+# Override the web container's standard HTTP_EXPOSE and HTTPS_EXPOSE
+# This is to expose the browsersync port.
+version: '3.6'
+services:
+  web:
+    expose:
+      - '3000'
+    environment:
+      - HTTP_EXPOSE=${DDEV_ROUTER_HTTP_PORT}:80,${DDEV_MAILHOG_PORT}:8025,3000:3000
+      - HTTPS_EXPOSE=${DDEV_ROUTER_HTTPS_PORT}:80,${DDEV_MAILHOG_HTTPS_PORT}:8025

--- a/config.cron.yaml
+++ b/config.cron.yaml
@@ -1,7 +1,21 @@
-#ddev-generated
-hooks:
-  # This will be executed whenever DDEV starts
-  post-start:
-    # This line creates a job, ddev-cron-time, and configures it to run every minute
-    # You can just `ls -l time.log` or `tail time.log` to see it happening.
-    - exec: echo '* * * * * root date | tee -a /var/www/html/time.log' | sudo tee -a /etc/cron.d/ddev-cron-time
+name: ddev-browsersync
+
+pre_install_actions:
+- | 
+  #ddev-nodisplay
+  if ! ( ddev debug capabilities 2>/dev/null | grep multiple-dockerfiles >/dev/null 2>&1 ) ; then
+    echo "This add-on requires DDEV v1.19.3 or higher, please upgrade." && exit 2
+  fi
+
+project_files:
+  - docker-compose.browsersync.yaml
+  - web-build/Dockerfile.ddev-browsersync
+  - browser-sync.js
+
+
+global_files:
+  - commands
+
+
+post_install_actions:
+

--- a/config.cron.yaml
+++ b/config.cron.yaml
@@ -1,3 +1,4 @@
+#ddev-generated
 hooks:
   # This will be executed whenever DDEV starts
   post-start:

--- a/config.cron.yaml
+++ b/config.cron.yaml
@@ -1,21 +1,7 @@
-name: ddev-browsersync
-
-pre_install_actions:
-- | 
-  #ddev-nodisplay
-  if ! ( ddev debug capabilities 2>/dev/null | grep multiple-dockerfiles >/dev/null 2>&1 ) ; then
-    echo "This add-on requires DDEV v1.19.3 or higher, please upgrade." && exit 2
-  fi
-
-project_files:
-  - docker-compose.browsersync.yaml
-  - web-build/Dockerfile.ddev-browsersync
-  - browser-sync.js
-
-
-global_files:
-  - commands
-
-
-post_install_actions:
-
+#ddev-generated
+hooks:
+  # This will be executed whenever DDEV starts
+  post-start:
+    # This line creates a job, ddev-cron-time, and configures it to run every minute
+    # You can just `ls -l time.log` or `tail time.log` to see it happening.
+    - exec: echo '* * * * * root date | tee -a /var/www/html/time.log' | sudo tee -a /etc/cron.d/ddev-cron-time

--- a/install.yaml
+++ b/install.yaml
@@ -2,7 +2,7 @@ name: ddev-cron
 
 pre_install_actions:
 - |
-  #ddev-nooutput
+  #ddev-nodisplay
   if ! ( ddev debug capabilities 2>/dev/null | grep multiple-dockerfiles >/dev/null 2>&1 ) ; then
     echo "This add-on requires DDEV v1.19.3 or higher, please upgrade." && exit 2
   fi

--- a/install.yaml
+++ b/install.yaml
@@ -1,114 +1,22 @@
-# tyler36/ddev-browsersync <!-- omit in toc -->
+name: ddev-cron
 
-[![tests](https://github.com/tyler36/ddev-browsersync/actions/workflows/tests.yml/badge.svg)](https://github.com/tyler36/ddev-browsersync/actions/workflows/tests.yml) ![project is maintained](https://img.shields.io/maintenance/yes/2022.svg)
+pre_install_actions:
+- |
+  #ddev-nodisplay
+  if ! ( ddev debug capabilities 2>/dev/null | grep multiple-dockerfiles >/dev/null 2>&1 ) ; then
+    echo "This add-on requires DDEV v1.19.3 or higher, please upgrade." && exit 2
+  fi
 
-- [Introduction](#introduction)
-- [Requirements](#requirements)
-- [Getting Started](#getting-started)
-  - [Laravel-mix example](#laravel-mix-example)
-- [TODO](#todo)
+# list of files and directories listed that are copied into project .ddev directory
+project_files:
+- config.cron.yaml
+- web-build/Dockerfile.ddev-cron
+- web-build/cron.conf
 
-## Introduction
 
-[Browsersync](https://browsersync.io/) is free software that features:
+# List of files and directories that are copied into the global .ddev directory
+global_files:
 
-- live reloads
-- click mirroring
-- network throttling
 
-This add-on allows you to run [Browsersync](https://browsersync.io/) through the DDEV web service.
+post_install_actions:
 
-## Getting Started
-
-This add-on requires DDEV v1.19.3 or higher.
-
-- Install the DDEV browsersync add-on:
-
-```shell
-ddev get tyler36/ddev-browsersync
-ddev restart
-ddev browsersync
-```
-
-The new `ddev browsersync` global command runs browsersync inside the web container and provides a
-link ("External") to the browsersync-update URL. Use the URL in the output that says something like "External: http://d9.ddev.site:3000".
-
-## What does this add-on do and add?
-
-1. Checks to make sure the DDEV version is adequate.
-2. Adds `.ddev/web-build/Dockerfile.ddev-browsersync`, which installs browsersync using npm.
-3. Adds a `browser-sync.js` to define the operation of the base setup.
-4. Adds a `.ddev/docker-compose.browsersync.yaml`, which exposes and routes the ports necessary.
-5. Adds a `ddev browsersync` shell command globally, which lets you easily start browsersync when you want it.
-
-## Other ways to use browsersync with this add-on
-There are many other options to integrate browsersync into your project, including:
-
-- [Grunt](https://browsersync.io/docs/grunt)
-- [Laravel-mix](https://laravel-mix.com/docs/4.0/browsersync)
-
-Please see [Browsersync documentation](https://browsersync.io/docs) for more details.
-PRs for install steps for specific frameworks are welcome.
-
-### Basic usage
-
-The existing example with just `ddev browsersync` should work out of the box.
-There is no need for additional configuration, but you may want to edit
-the `.ddev/browser-sync.js` file to specify exactly what files and directories
-should be watched. If you watch less things it's easier on your computer.
-
-### Problems
-
-* If you get `Error: ENOSPC: System limit for number of file watchers reached, watch '/var/www/html/web/core/themes/classy/images/icons/video-x-generic.png'` it means you either have to increase the file watcher limit or decrease the number of files you're watching.
-  * To decrease the number of files you're watching, edit the `ignore` section in `browser-sync.js` (or another config file if you have a more complex setup).
-  * On colima, `colima ssh` and `sudo sysctl fs.inotify.max_user_watches` to see how many watches you have. To increase it, use something like `sudo sysctl -w fs.inotify.max_user_watches=2048576`. Unfortunately, this has to be done on every colima restart.
-  * On Docker Desktop for Mac, `docker run -it --privileged --pid=host justincormack/nsenter1` and `sysctl -w fs.inotify.max_user_watches=1048576`. Unfortunately, this has to be done again on every Docker restart.
-  * On Docker Desktop for Windows, add or edit `~/.wslconfig` with these contents:
-    ```
-    [wsl2]
-    kernelCommandLine = "fs.inotify.max_user_watches=1048576"
-    ```
-  * On Linux, you can change `fs.inotify.max_user_watches` on the host in /etc/sysctl.d/local.conf or elsewhere.
-
-### Laravel-mix configuration
-
-Demo: <https://github.com/tyler36/browsersync-demo>
-
-- Update `webpack.mix.js`
-
-```js
-// Use the HOSTNAME provided by DDEV
-let url = process.env.DDEV_HOSTNAME;
-
-mix.js('resources/js/app.js', 'public/js')
-    .postCss('resources/css/app.css', 'public/css', [
-        //
-    ])
-    .browserSync({
-        proxy: "localhost",
-        host:  url,
-        open:  false,
-        ui: false
-    });
-```
-
-- Start browsersync service
-
-```shell
-ddev exec npm run watch
-...
-[Browsersync] Proxying: http://browsersync-demo.ddev.site
-[Browsersync] Access URLs:
- ---------------------------------------------------
-       Local: http://localhost:3000
-    External: http://browsersync-demo.ddev.site:3000
- ---------------------------------------------------
-```
-
-- Browsersync will be running at `https://browsersync-demo.ddev.site:3000`
-
-## TODO
-
-- Browsersync proxy HTTPS version
-
-**Contributed and maintained by [tyler36](https://github.com/tyler36)**

--- a/install.yaml
+++ b/install.yaml
@@ -2,6 +2,7 @@ name: ddev-cron
 
 pre_install_actions:
 - |
+  #ddev-nooutput
   if ! ( ddev debug capabilities 2>/dev/null | grep multiple-dockerfiles >/dev/null 2>&1 ) ; then
     echo "This add-on requires DDEV v1.19.3 or higher, please upgrade." && exit 2
   fi
@@ -14,9 +15,7 @@ project_files:
 
 # List of files and directories that are copied into the global .ddev directory
 global_files:
-# - commands
-# - homeadditions
+
 
 post_install_actions:
-# - chmod +x ~/.ddev/commands/web/somecommand
-# - perl -pi -e 's/oldstring/newstring/g' docker-compose.ddev-cron.yaml
+

--- a/install.yaml
+++ b/install.yaml
@@ -10,7 +10,8 @@ pre_install_actions:
 # list of files and directories listed that are copied into project .ddev directory
 project_files:
 - config.cron.yaml
-- web-build
+- web-build/Dockerfile.ddev-cron
+- web-build/cron.conf
 
 
 # List of files and directories that are copied into the global .ddev directory

--- a/install.yaml
+++ b/install.yaml
@@ -1,22 +1,114 @@
-name: ddev-cron
+# tyler36/ddev-browsersync <!-- omit in toc -->
 
-pre_install_actions:
-- |
-  #ddev-nodisplay
-  if ! ( ddev debug capabilities 2>/dev/null | grep multiple-dockerfiles >/dev/null 2>&1 ) ; then
-    echo "This add-on requires DDEV v1.19.3 or higher, please upgrade." && exit 2
-  fi
+[![tests](https://github.com/tyler36/ddev-browsersync/actions/workflows/tests.yml/badge.svg)](https://github.com/tyler36/ddev-browsersync/actions/workflows/tests.yml) ![project is maintained](https://img.shields.io/maintenance/yes/2022.svg)
 
-# list of files and directories listed that are copied into project .ddev directory
-project_files:
-- config.cron.yaml
-- web-build/Dockerfile.ddev-cron
-- web-build/cron.conf
+- [Introduction](#introduction)
+- [Requirements](#requirements)
+- [Getting Started](#getting-started)
+  - [Laravel-mix example](#laravel-mix-example)
+- [TODO](#todo)
 
+## Introduction
 
-# List of files and directories that are copied into the global .ddev directory
-global_files:
+[Browsersync](https://browsersync.io/) is free software that features:
 
+- live reloads
+- click mirroring
+- network throttling
 
-post_install_actions:
+This add-on allows you to run [Browsersync](https://browsersync.io/) through the DDEV web service.
 
+## Getting Started
+
+This add-on requires DDEV v1.19.3 or higher.
+
+- Install the DDEV browsersync add-on:
+
+```shell
+ddev get tyler36/ddev-browsersync
+ddev restart
+ddev browsersync
+```
+
+The new `ddev browsersync` global command runs browsersync inside the web container and provides a
+link ("External") to the browsersync-update URL. Use the URL in the output that says something like "External: http://d9.ddev.site:3000".
+
+## What does this add-on do and add?
+
+1. Checks to make sure the DDEV version is adequate.
+2. Adds `.ddev/web-build/Dockerfile.ddev-browsersync`, which installs browsersync using npm.
+3. Adds a `browser-sync.js` to define the operation of the base setup.
+4. Adds a `.ddev/docker-compose.browsersync.yaml`, which exposes and routes the ports necessary.
+5. Adds a `ddev browsersync` shell command globally, which lets you easily start browsersync when you want it.
+
+## Other ways to use browsersync with this add-on
+There are many other options to integrate browsersync into your project, including:
+
+- [Grunt](https://browsersync.io/docs/grunt)
+- [Laravel-mix](https://laravel-mix.com/docs/4.0/browsersync)
+
+Please see [Browsersync documentation](https://browsersync.io/docs) for more details.
+PRs for install steps for specific frameworks are welcome.
+
+### Basic usage
+
+The existing example with just `ddev browsersync` should work out of the box.
+There is no need for additional configuration, but you may want to edit
+the `.ddev/browser-sync.js` file to specify exactly what files and directories
+should be watched. If you watch less things it's easier on your computer.
+
+### Problems
+
+* If you get `Error: ENOSPC: System limit for number of file watchers reached, watch '/var/www/html/web/core/themes/classy/images/icons/video-x-generic.png'` it means you either have to increase the file watcher limit or decrease the number of files you're watching.
+  * To decrease the number of files you're watching, edit the `ignore` section in `browser-sync.js` (or another config file if you have a more complex setup).
+  * On colima, `colima ssh` and `sudo sysctl fs.inotify.max_user_watches` to see how many watches you have. To increase it, use something like `sudo sysctl -w fs.inotify.max_user_watches=2048576`. Unfortunately, this has to be done on every colima restart.
+  * On Docker Desktop for Mac, `docker run -it --privileged --pid=host justincormack/nsenter1` and `sysctl -w fs.inotify.max_user_watches=1048576`. Unfortunately, this has to be done again on every Docker restart.
+  * On Docker Desktop for Windows, add or edit `~/.wslconfig` with these contents:
+    ```
+    [wsl2]
+    kernelCommandLine = "fs.inotify.max_user_watches=1048576"
+    ```
+  * On Linux, you can change `fs.inotify.max_user_watches` on the host in /etc/sysctl.d/local.conf or elsewhere.
+
+### Laravel-mix configuration
+
+Demo: <https://github.com/tyler36/browsersync-demo>
+
+- Update `webpack.mix.js`
+
+```js
+// Use the HOSTNAME provided by DDEV
+let url = process.env.DDEV_HOSTNAME;
+
+mix.js('resources/js/app.js', 'public/js')
+    .postCss('resources/css/app.css', 'public/css', [
+        //
+    ])
+    .browserSync({
+        proxy: "localhost",
+        host:  url,
+        open:  false,
+        ui: false
+    });
+```
+
+- Start browsersync service
+
+```shell
+ddev exec npm run watch
+...
+[Browsersync] Proxying: http://browsersync-demo.ddev.site
+[Browsersync] Access URLs:
+ ---------------------------------------------------
+       Local: http://localhost:3000
+    External: http://browsersync-demo.ddev.site:3000
+ ---------------------------------------------------
+```
+
+- Browsersync will be running at `https://browsersync-demo.ddev.site:3000`
+
+## TODO
+
+- Browsersync proxy HTTPS version
+
+**Contributed and maintained by [tyler36](https://github.com/tyler36)**

--- a/web-build/Dockerfile.ddev-cron
+++ b/web-build/Dockerfile.ddev-cron
@@ -1,3 +1,4 @@
+#ddev-generated
 # Install cron package; this can be done in webimage_extra_packages, but put it here for now.
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests cron
 # Tell supervisord to start cron service in cron.conf

--- a/web-build/cron.conf
+++ b/web-build/cron.conf
@@ -1,3 +1,4 @@
+#ddev-generated
 [program:cron]
 command=sudo /usr/sbin/cron -f
 autorestart=true


### PR DESCRIPTION
* Dockerfile.example didn't have #ddev-generated in it, so ddev HEAD refused to overwrite
* We were using a directory replacement (web-build) instead of installing individual files (web-build/Dockerfile.cron), so switch to that approach instead of triggering this bug (fixed in https://github.com/drud/ddev/pull/3916)
* Add #ddev-nodisplay to the capabilities check so it doesn't make so much noise (new feature, but does no harm with existing ddev versions)
* Only test ddev stable and HEAD versions, as edge shouldn't really add any particular value. HEAD would break first.