### PR TITLE
Use crontab for cron, add examples to README including typo3 scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ The `config.cron.yaml` is a simple setup of a trivial cron job within the DDEV w
 hooks:
   post-start:
     # This adds an every-minute cronjob for your user; it runs "date" and appends that
-    # to the "date.log" in your project root.
-    # You can just `ls -l date.log` or `tail -f date.log` to see it happening.
+    # to the "time.log" in your project root.
+    # You can just `ls -l time.log` or `tail -f time.log` to see it happening.
     # The crontab can have more than one line for multiple jobs.
     # `ddev exec crontab -l` will show you the current crontab configuration
-    - exec: printf "SHELL=/bin/bash\n* * * * * date >> /var/www/html/date.log\n" | crontab
+    - exec: printf "SHELL=/bin/bash\n* * * * * date >> /var/www/html/time.log\n" | crontab
 ```
 
-The default file configures a job to write the date to a log file `date.log` every minute.
+The default file configures a job to write the date to a log file `time.log` every minute.
 It is a simple arbitary example to show the service is working, and remind the user to change it to something more appropriate. You can add additional files into /etc/cron.d, or add additional lines to this one.
 
 * If you need help figuring out the syntax of a cron job, see [crontab guru](https://crontab.guru/).
@@ -56,13 +56,13 @@ It is a simple arbitary example to show the service is working, and remind the u
 **TYPO3 scheduler**: A cron to add on to the example and then run the TYPO3 scheduler every minute might be:
 
 ```yaml
-  - exec: printf "SHELL=/bin/bash\n* * * * * date |& tee -a /var/www/html/date.log\n* * * * * IS_DDEV_PROJECT=true /var/www/html/vendor/bin/typo3 scheduler:run -vv |& tee -a /var/www/html/scheduler-log.txt\n" | crontab
+  - exec: printf "SHELL=/bin/bash\n* * * * * date |& tee -a /var/www/html/time.log\n* * * * * IS_DDEV_PROJECT=true /var/www/html/vendor/bin/typo3 scheduler:run -vv |& tee -a /var/www/html/scheduler-log.txt\n" | crontab
 
 ```
 See the results of this with `ddev exec crontab -l`:
 ```
 SHELL=/bin/bash
-* * * * * date |& tee -a /var/www/html/date.log
+* * * * * date |& tee -a /var/www/html/time.log
 * * * * * cd /var/www/html && IS_DDEV_PROJECT=true vendor/bin/typo3 scheduler:run -vv |& tee -a /var/www/html/scheduler-log.txt
 ```
 

--- a/README.md
+++ b/README.md
@@ -33,11 +33,15 @@ The `config.cron.yaml` is a simple setup of a trivial cron job within the DDEV w
 ```yaml
 hooks:
   post-start:
-      # This line creates a cron job, ddev-cron-time, and configures it to run every minute
-    - exec: echo '*/1 * * * * root date | tee -a /var/www/html/time.log' | sudo tee -a /etc/cron.d/ddev-cron-time
+    # This adds an every-minute cronjob for your user; it runs "date" and appends that
+    # to the "date.log" in your project root.
+    # You can just `ls -l date.log` or `tail -f date.log` to see it happening.
+    # The crontab can have more than one line for multiple jobs.
+    # `ddev exec crontab -l` will show you the current crontab configuration
+    - exec: echo "* * * * * date | tee -a /var/www/html/date.log" | crontab
 ```
 
-The default file configures a job (`ddev-cron-time`) to write the date to a log file `time.log` every minute.
+The default file configures a job to write the date to a log file `date.log` every minute.
 It is a simple arbitary example to show the service is working, and remind the user to change it to something more appropriate. You can add additional files into /etc/cron.d, or add additional lines to this one.
 
 **Contributed and maintained by [@tyler36](https://github.com/tyler36) based on the original [Running TYPO3 Cron inside the web container](https://github.com/drud/ddev-contrib/tree/master/recipes/cronjob) by [@thomaskieslich](https://github.com/thomaskieslich)**

--- a/README.md
+++ b/README.md
@@ -38,11 +38,40 @@ hooks:
     # You can just `ls -l date.log` or `tail -f date.log` to see it happening.
     # The crontab can have more than one line for multiple jobs.
     # `ddev exec crontab -l` will show you the current crontab configuration
-    - exec: echo "* * * * * date | tee -a /var/www/html/date.log" | crontab
+    - exec: printf "SHELL=/bin/bash\n* * * * * date >> /var/www/html/date.log\n" | crontab
 ```
 
 The default file configures a job to write the date to a log file `date.log` every minute.
 It is a simple arbitary example to show the service is working, and remind the user to change it to something more appropriate. You can add additional files into /etc/cron.d, or add additional lines to this one.
+
+* If you need help figuring out the syntax of a cron job, see [crontab guru](https://crontab.guru/).
+* For the usage of `crontab` see [crontab man page](https://manpages.debian.org/buster/cron/crontab.1.en.html).
+* You can experiment with the `crontab` command inside the container by `ddev ssh` and then `crontab -e` for example, or use `ddev exec crontab -e`.
+* If you want the cron to run on your local time instead of UTC, make sure to set `timezone` in your `.ddev/config.yaml`.
+* Make sure that when you have tried manually executing the command you want to run inside the container and that it gets the expected results.
+* If you are running a CMS command that requires access to the database, set the environment variable `IS_DDEV_PROJECT=true`
+
+## Examples
+
+**TYPO3 scheduler**: A cron to add on to the example and then run the TYPO3 scheduler every minute might be:
+
+```yaml
+  - exec: printf "SHELL=/bin/bash\n* * * * * date |& tee -a /var/www/html/date.log\n* * * * * IS_DDEV_PROJECT=true /var/www/html/vendor/bin/typo3 scheduler:run -vv |& tee -a /var/www/html/scheduler-log.txt\n" | crontab
+
+```
+See the results of this with `ddev exec crontab -l`:
+```
+SHELL=/bin/bash
+* * * * * date |& tee -a /var/www/html/date.log
+* * * * * cd /var/www/html && IS_DDEV_PROJECT=true vendor/bin/typo3 scheduler:run -vv |& tee -a /var/www/html/scheduler-log.txt
+```
+
+**Drupal cron**: A cron to run drupal's cron every 10 minutes via drush might be:
+
+```yaml
+  - exec: printf "SHELL=/bin/bash\n*/10 * * * * IS_DDEV_PROJECT=true DDEV_PHP_VERSION=8.0 /var/www/html/vendor/bin/drush cron -v |& tee -a /var/www/html/cron-log.txt\n" | crontab
+```
+
 
 **Contributed and maintained by [@tyler36](https://github.com/tyler36) based on the original [Running TYPO3 Cron inside the web container](https://github.com/drud/ddev-contrib/tree/master/recipes/cronjob) by [@thomaskieslich](https://github.com/thomaskieslich)**
 

--- a/config.cron.yaml
+++ b/config.cron.yaml
@@ -8,4 +8,4 @@ hooks:
     # You can just `ls -l date.log` or `tail -f date.log` to see it happening.
     # The crontab can have more than one line for multiple jobs.
     # `ddev exec crontab -l` will show you the current crontab configuration
-    - exec: echo "* * * * * date | tee -a /var/www/html/date.log" | crontab
+    - exec: printf "SHELL=/bin/bash\n* * * * * date | tee -a /var/www/html/date.log\n" | crontab

--- a/config.cron.yaml
+++ b/config.cron.yaml
@@ -1,7 +1,11 @@
 #ddev-generated
+# Remove the line above if you don't want this file to be overwritten when you run
+# ddev get drud/ddev-cron
 hooks:
-  # This will be executed whenever DDEV starts
   post-start:
-    # This line creates a job, ddev-cron-time, and configures it to run every minute
-    # You can just `ls -l time.log` or `tail time.log` to see it happening.
-    - exec: echo '* * * * * root date | tee -a /var/www/html/time.log' | sudo tee -a /etc/cron.d/ddev-cron-time
+    # This adds an every-minute cronjob for your user; it runs "date" and appends that
+    # to the "date.log" in your project root.
+    # You can just `ls -l date.log` or `tail -f date.log` to see it happening.
+    # The crontab can have more than one line for multiple jobs.
+    # `ddev exec crontab -l` will show you the current crontab configuration
+    - exec: echo "* * * * * date | tee -a /var/www/html/date.log" | crontab

--- a/config.cron.yaml
+++ b/config.cron.yaml
@@ -4,8 +4,8 @@
 hooks:
   post-start:
     # This adds an every-minute cronjob for your user; it runs "date" and appends that
-    # to the "date.log" in your project root.
-    # You can just `ls -l date.log` or `tail -f date.log` to see it happening.
+    # to the "time.log" in your project root.
+    # You can just `ls -l time.log` or `tail -f time.log` to see it happening.
     # The crontab can have more than one line for multiple jobs.
     # `ddev exec crontab -l` will show you the current crontab configuration
-    - exec: printf "SHELL=/bin/bash\n* * * * * date | tee -a /var/www/html/date.log\n" | crontab
+    - exec: printf "SHELL=/bin/bash\n* * * * * date | tee -a /var/www/html/time.log\n" | crontab

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -37,7 +37,7 @@ teardown() {
 @test "install from release" {
   set -eu -o pipefail
   cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
-  echo "# ddev get tyler36/ddev-cron with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  echo "# ddev get drud/ddev-cron with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
   ddev get drud/ddev-cron
   ddev restart
 

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -31,7 +31,7 @@ teardown() {
  # Make sure cron process is running
   ddev exec 'sudo killall -0 cron'
  # ASSERT: Make sure time.log got a line written to it.
-  grep UTC date.log
+  grep UTC time.log
 }
 
 @test "install from release" {
@@ -45,5 +45,5 @@ teardown() {
  # Make sure cron process is running
   ddev exec 'sudo killall -0 cron'
  # ASSERT: Make sure time.log got a line written to it.
-  grep UTC date.log
+  grep UTC time.log
 }

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -31,13 +31,13 @@ teardown() {
  # Make sure cron process is running
   ddev exec 'sudo killall -0 cron'
  # ASSERT: Make sure time.log got a line written to it.
-  grep UTC time.log
+  grep UTC date.log
 }
 
 @test "install from release" {
   set -eu -o pipefail
   cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
-  echo "# ddev get drud/ddev-cron with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  echo "# ddev get tyler36/ddev-cron with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
   ddev get drud/ddev-cron
   ddev restart
 
@@ -45,5 +45,5 @@ teardown() {
  # Make sure cron process is running
   ddev exec 'sudo killall -0 cron'
  # ASSERT: Make sure time.log got a line written to it.
-  grep UTC time.log
+  grep UTC date.log
 }

--- a/web-build/Dockerfile.ddev-cron
+++ b/web-build/Dockerfile.ddev-cron
@@ -3,3 +3,5 @@
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests cron
 # Tell supervisord to start cron service in cron.conf
 ADD cron.conf /etc/supervisor/conf.d
+# Make it so you can add to cron.d without root privileges
+RUN chmod 777 /etc/cron.d /var/run

--- a/web-build/cron.conf
+++ b/web-build/cron.conf
@@ -1,5 +1,8 @@
 #ddev-generated
 [program:cron]
-command=sudo /usr/sbin/cron -f
+command=sudo /usr/sbin/cron -f -L7
 autorestart=true
 startretries=10
+stdout_logfile=/proc/self/fd/2
+stdout_logfile_maxbytes=0
+redirect_stderr=true


### PR DESCRIPTION
* Use `crontab` instead of putting things directly into /etc/cron.d. This makes commands run as the user instead of as root, avoiding permissions problems
* Provide TYPO3 scheduler and drupal examples

This PR can be tested with `ddev get https://github.com/rfay/ddev-cron/tarball/20220721_easier_perms_cron.d`

The new README is at https://github.com/drud/ddev-cron/blob/8db9f512e8c1400a0f8363d75da2bb74aaa253bf/README.md