### PR TITLE
Add health check clarification

### DIFF
--- a/tests/test.bats
+++ b/tests/test.bats
@@ -21,7 +21,9 @@ teardown() {
 }
 
 health_checks() {
-  # Make sure cron process is running
+  # Make sure cron process is running.
+  # We use `time_cron_checks` to check the example cron job is actually correctly implemented.
+  # This is due to the need to test the health-check when there are no jobs added.
   ddev exec 'sudo killall -0 cron'
 }
 


### PR DESCRIPTION
This PR adds some testing comments.

## Background

In the [DDEV Testing Infrastructure](https://ddev.com/blog/contributor-training/) live training, @rfay browsed to this repo as an example of testing addons. At quick glance, he was suprised at the lightweight health check used.

Due to the re-write in #35, an addional test was needed to ensure the service ran when there are no jobs. I decided to re-use the same health check to ensure consistency. However, this meant the actual implented job check would need to be extracted.

Or do we need a better "health_checks" check?
