### PR TITLE
Added cron example for WordPress in readme, fixes #34

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,17 @@ Every minute, it writes the current time (UTC timezone) to `./time.log`.
 * * * * * cd /var/www/html && IS_DDEV_PROJECT=true php artisan schedule:run >> /dev/null 2>&1
 ```
 
+### WordPress cron
+
+- Create a `./.ddev/web-build/wordpress.cron` file
+- Add the following code to trigger the WordPress scheduler.
+
+```cron
+*/15 * * * * IS_DDEV_PROJECT=true DDEV_PHP_VERSION=8.1 cd /var/www/html && /usr/local/bin/wp cron event run --due-now 2>&1 | tee -a /var/www/html/cron.log
+```
+- This configuration will run the WordPress scheduler every 15 minutes and will create a `cron.log` file in the root of your project
+
+
 **Contributed and maintained by [@tyler36](https://github.com/tyler36) based on the original [Running TYPO3 Cron inside the web container](https://github.com/ddev/ddev-contrib/tree/master/recipes/cronjob) by [@thomaskieslich](https://github.com/thomaskieslich)**
 
 **Originally Contributed by [@thomaskieslich](https://github.com/thomaskieslich) in <https://github.com/ddev/ddev-contrib/tree/master/recipes/cronjob>)**


### PR DESCRIPTION
It's a little help, lately I needed to add the WordPress cron to DDEV-CRON and I had a lot of difficulty, here is a simple example. Added the cron example for WordPress in the readme.

Basically it will run the WordPress scheduler every 15 minutes and will also create a log file in the root of the project. If you didn't want the log file to be created, just remove this part of the code `2>&1 | tee -a /var/www/html/cron.log`

Print(01) Change
![image](https://github.com/ddev/ddev-cron/assets/72773757/fcad7e67-5241-49d1-a1f9-fbbe0562d722)

Print(02, 03) Test
![image](https://github.com/ddev/ddev-cron/assets/72773757/3ad7b933-dfdd-4f8b-adb4-988f613bc516)

![image](https://github.com/ddev/ddev-cron/assets/72773757/4d848c16-99d8-4ef2-8ada-a5bd39b230b1)


