### PR TITLE
⏫ bump "github-action-add-on-test"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,10 @@ on:
         required: false
         default: "false"
 
+# Permissions required for keepalive-workflow in ddev/github-action-add-on-test
+permissions:
+  contents: write
+
 jobs:
   tests:
     strategy:
@@ -24,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: ddev/github-action-add-on-test@v1
+    - uses: ddev/github-action-add-on-test@v2
       with:
         ddev_version: ${{ matrix.ddev_version }}
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ on:
 
 # Permissions required for keepalive-workflow in ddev/github-action-add-on-test
 permissions:
-  contents: write
+  actions: write
 
 jobs:
   tests:


### PR DESCRIPTION
## The Issue

The official workflow uses the keep-alive action. This generates commit after inactivity to prevent automated testing from being disabled.

## How This PR Solves The Issue

This PR updates the workflow to a version that does not generate commits.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)
https://github.com/gautamkrishnar/keepalive-workflow/releases/tag/2.0.0

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

