### PR TITLE
fix: do not fail on `apt-get update`

### DIFF
--- a/web-build/Dockerfile.ddev-cron
+++ b/web-build/Dockerfile.ddev-cron
@@ -1,6 +1,6 @@
 #ddev-generated
 # Install cron package; this can be done in webimage_extra_packages, but put it here for now.
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests cron
+RUN (apt-get update || true) && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests cron
 
 # Copy our custom config
 COPY ./cron.conf /etc/supervisor/conf.d/cron.conf


### PR DESCRIPTION
## The Issue

- https://github.com/ddev/ddev/pull/5623

We must not allow apt-get update to fail if some repository is down, because it can stop the webserver from starting.

## How This PR Solves The Issue

Allows `apt-get install` to continue after a fail for `apt-get update`.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

