### PR TITLE
Add Contao example to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - [Useful sites and debugging](#useful-sites-and-debugging)
 - [Examples](#examples)
   - [Logging current time](#logging-current-time)
+  - [Contao cron](#contao-cron)
   - [Drupal cron](#drupal-cron)
   - [Laravel cron](#laravel-cron)
   - [OpenMage cron](#openmage-cron)

--- a/README.md
+++ b/README.md
@@ -87,6 +87,16 @@ Every minute, it writes the current time (UTC timezone) to `./time.log`.
 - Restart the DDEV project to start the time example.
 - After at least a minute, you should see `./time.log` containing the web container's current time.
 
+### Contao cron
+
+- Create a `./.ddev/web-build/contao.cron` file
+- Add the following code to run the Contao scheduler every minute.
+  - Adjust `php8.4` to match your DDEV project's PHP version
+
+```cron
+* * * * * /usr/bin/php8.4 /var/www/html/vendor/bin/contao-console contao:cron
+```
+
 ### Drupal cron
 
 - Create a `./.ddev/web-build/drupal.cron` file

--- a/README.md
+++ b/README.md
@@ -92,10 +92,9 @@ Every minute, it writes the current time (UTC timezone) to `./time.log`.
 
 - Create a `./.ddev/web-build/contao.cron` file
 - Add the following code to run the Contao scheduler every minute.
-  - Adjust `php8.4` to match your DDEV project's PHP version
 
 ```cron
-* * * * * /usr/bin/php8.4 /var/www/html/vendor/bin/contao-console contao:cron
+* * * * * php /var/www/html/vendor/bin/contao-console contao:cron
 ```
 
 ### Drupal cron


### PR DESCRIPTION
Add example for Contao CMS. This cronjob is required for the search function to work in the Contao backend.

[Contao Backend Search Requirement](https://docs.contao.org/manual/en/installation/system-requirements/backend-search/#basic-requirement-1-the-cronjob-framework)
[Contao Cronjob Framework](https://docs.contao.org/manual/en/performance/cronjobs/)