### PR TITLE
Add magento cron to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,15 @@ Every minute, it writes the current time (UTC timezone) to `./time.log`.
 * * * * * /var/www/html/cron.sh
 ```
 
+### Magento 2 / Mage-OS cron
+
+- Create a `./.ddev/web-build/magento.cron` file
+- Add the following code to run the Magento scheduler every minute.
+
+```cron
+* * * * * php /var/www/html/bin/magento cron:run
+```
+
 ### TYPO3 scheduler
 
 - Create a `./.ddev/web-build/typo3.cron` file


### PR DESCRIPTION
Hi!

I've noticed there are instructions for Magento 1 / OpenMage but not for Magento 2 / Mage‑OS, so here they are.